### PR TITLE
Support encrypt to HexString

### DIFF
--- a/src/XXTEA.h
+++ b/src/XXTEA.h
@@ -30,8 +30,6 @@
 + (NSString *) encryptStringToBase64String:(NSString *)data key:(NSData *)key;
 + (NSString *) encryptStringToBase64String:(NSString *)data stringKey:(NSString *)key;
 
-+ (NSString *) convertBytesToHex:(NSData *)encrypt_data;
-
 + (NSString *) encryptToHexString:(NSData *)data key:(NSData *)key;
 + (NSString *) encryptToHexString:(NSData *)data stringKey:(NSString *)key;
 
@@ -49,8 +47,6 @@
 
 + (NSString *) decryptBase64StringToString:(NSString *)data key:(NSData *)key;
 + (NSString *) decryptBase64StringToString:(NSString *)data stringKey:(NSString *)key;
-
-+ (NSData *) convertHexToBytes:(NSString *)hexString;
 
 + (NSData *) decryptHexString:(NSString *)data key:(NSData *)key;
 + (NSData *) decryptHexString:(NSString *)data stringKey:(NSString *)key;

--- a/src/XXTEA.h
+++ b/src/XXTEA.h
@@ -21,8 +21,6 @@
 + (NSData *) encrypt:(NSData *)data key:(NSData *)key;
 + (NSData *) encrypt:(NSData *)data stringKey:(NSString *)key;
 
-+ (NSString *)encryptWithHexString: (NSString *)data stringKey:(NSString *)key;
-
 + (NSString *) encryptToBase64String:(NSData *)data key:(NSData *)key;
 + (NSString *) encryptToBase64String:(NSData *)data stringKey:(NSString *)key;
 
@@ -31,6 +29,14 @@
 
 + (NSString *) encryptStringToBase64String:(NSString *)data key:(NSData *)key;
 + (NSString *) encryptStringToBase64String:(NSString *)data stringKey:(NSString *)key;
+
++ (NSString *) convertBytesToHex:(NSData *)encrypt_data;
+
++ (NSString *) encryptToHexString:(NSData *)data key:(NSData *)key;
++ (NSString *) encryptToHexString:(NSData *)data stringKey:(NSString *)key;
+
++ (NSString *) encryptStringToHexString:(NSString *)data key:(NSData *)key;
++ (NSString *) encryptStringToHexString:(NSString *)data stringKey:(NSString *)key;
 
 + (NSData *) decrypt:(NSData *)data key:(NSData *)key;
 + (NSData *) decrypt:(NSData *)data stringKey:(NSString *)key;
@@ -43,6 +49,14 @@
 
 + (NSString *) decryptBase64StringToString:(NSString *)data key:(NSData *)key;
 + (NSString *) decryptBase64StringToString:(NSString *)data stringKey:(NSString *)key;
+
++ (NSData *) convertHexToBytes:(NSString *)hexString;
+
++ (NSData *) decryptHexString:(NSString *)data key:(NSData *)key;
++ (NSData *) decryptHexString:(NSString *)data stringKey:(NSString *)key;
+
++ (NSString *) decryptHexStringToString:(NSString *)data key:(NSData *)key;
++ (NSString *) decryptHexStringToString:(NSString *)data stringKey:(NSString *)key;
 
 @end
 

--- a/src/XXTEA.h
+++ b/src/XXTEA.h
@@ -21,6 +21,8 @@
 + (NSData *) encrypt:(NSData *)data key:(NSData *)key;
 + (NSData *) encrypt:(NSData *)data stringKey:(NSString *)key;
 
++ (NSString *)encryptWithHexString: (NSString *)data stringKey:(NSString *)key;
+
 + (NSString *) encryptToBase64String:(NSData *)data key:(NSData *)key;
 + (NSString *) encryptToBase64String:(NSData *)data stringKey:(NSString *)key;
 

--- a/src/XXTEA.m
+++ b/src/XXTEA.m
@@ -220,7 +220,6 @@ static uint8_t * xxtea_ubyte_decrypt(const uint8_t * data, size_t len, const uin
     NSData * encrypt_data = [self encrypt:data key:key];
     return [self convertBytesToHex:encrypt_data];
 }
-}
 + (NSString *)encryptToHexString: (NSData *)data stringKey:(NSString *)key {
     NSData * encrypt_data = [self encrypt:data stringKey:key];
     return [self convertBytesToHex:encrypt_data];
@@ -280,15 +279,15 @@ static uint8_t * xxtea_ubyte_decrypt(const uint8_t * data, size_t len, const uin
 }
 + (NSData *) decryptHexString:(NSString *)data stringKey:(NSString *)key {
     NSData * bytesData = [self convertHexToBytes:data];
-    return [self decrypt:originalHashData stringKey:key];
+    return [self decrypt:bytesData stringKey:key];
 }
 + (NSString *) decryptHexStringToString:(NSString *)data key:(NSData *)key {
     NSData * bytesData = [self convertHexToBytes:data];
-    return [self decryptToString: data key:key];
+    return [self decryptToString:bytesData key:key];
 }
 + (NSString *) decryptHexStringToString:(NSString *)data stringKey:(NSString *)key {
     NSData * bytesData = [self convertHexToBytes:data];
-    return [self decryptToString: data stringKey:key];
+    return [self decryptToString:bytesData stringKey:key];
 }
 
 @end

--- a/src/XXTEA.m
+++ b/src/XXTEA.m
@@ -274,20 +274,28 @@ static char _NSData_BytesConversionString_[512] = "000102030405060708090a0b0c0d0
     return [self decryptBase64StringToString:data key:[key dataUsingEncoding:NSUTF8StringEncoding]];
 }
 + (NSData *) convertHexToBytes:(NSString *)hexString {
-    NSString* string = [hexString lowercaseString];
-    NSMutableData *data= [NSMutableData new];
-    unsigned char whole_byte;
-    char byte_chars[3] = {'\0','\0','\0'};
-    int i = 0;
-    int length = (int) string.length;
-    while (i < length-1) {
-        char c = [string characterAtIndex:i++];
-        if (c < '0' || (c > '9' && c < 'a') || c > 'f')
-            continue;
-        byte_chars[0] = c;
-        byte_chars[1] = [string characterAtIndex:i++];
-        whole_byte = strtol(byte_chars, NULL, 16);
-        [data appendBytes:&whole_byte length:1];
+    NSMutableData *data = [[NSMutableData alloc] init];
+    NSString *inputStr = [hexString uppercaseString];
+    NSString *hexChars = @"0123456789ABCDEF";
+    Byte b1,b2;
+    b1 = 255;
+    b2 = 255;
+    for (int i=0; i<hexString.length; i++) {
+        NSString *subStr = [inputStr substringWithRange:NSMakeRange(i, 1)];
+        NSRange loc = [hexChars rangeOfString:subStr];
+
+        if (loc.location == NSNotFound) continue;
+
+        if (255 == b1) {
+            b1 = (Byte)loc.location;
+        }else {
+            b2 = (Byte)loc.location;
+            Byte *bytes = malloc(sizeof(Byte) *1);
+            bytes[0] = ((b1<<4) & 0xf0) | (b2 & 0x0f);
+            [data appendBytes:bytes length:1];
+
+            b1 = b2 = 255;
+        }
     }
     return data;
 }

--- a/src/XXTEA.m
+++ b/src/XXTEA.m
@@ -190,15 +190,6 @@ static uint8_t * xxtea_ubyte_decrypt(const uint8_t * data, size_t len, const uin
 + (NSData *) encrypt:(NSData *)data stringKey:(NSString *)key {
     return [self encrypt:data key:[key dataUsingEncoding:NSUTF8StringEncoding]];
 }  
-+ (NSString *)encryptWithHexString: (NSString *)data stringKey:(NSString *)key {
-    NSData * encrypt_data = [XXTEA encryptString:data stringKey:key];
-    const unsigned char *dataBytes = [encrypt_data bytes];
-    NSMutableString *hexString = [NSMutableString stringWithCapacity:[encrypt_data length] * 2];
-    for (int i=0; i<[encrypt_data length]; ++i) {
-        [hexString appendFormat:@"%02lX", (unsigned long)dataBytes[i]];
-    }
-    return hexString;
-}
 + (NSString *) encryptToBase64String:(NSData *)data key:(NSData *)key {
     return [[self encrypt:data key:key] base64EncodedStringWithOptions:0];
 }
@@ -216,6 +207,31 @@ static uint8_t * xxtea_ubyte_decrypt(const uint8_t * data, size_t len, const uin
 }
 + (NSString *) encryptStringToBase64String:(NSString *)data stringKey:(NSString *)key {
     return [self encryptToBase64String:[data dataUsingEncoding:NSUTF8StringEncoding] stringKey:key];
+}
++ (NSString *) convertBytesToHex:(NSData *)encrypt_data {
+    const unsigned char * dataBytes = [encrypt_data bytes];
+    NSMutableString * hexString = [NSMutableString stringWithCapacity:[encrypt_data length] * 2];
+    for (int i=0; i<[encrypt_data length]; ++i) {
+        [hexString appendFormat:@"%02lX", (unsigned long)dataBytes[i]];
+    }
+    return hexString;
+}
++ (NSString *) encryptToHexString:(NSData *)data key:(NSData *)key {
+    NSData * encrypt_data = [self encrypt:data key:key];
+    return [self convertBytesToHex:encrypt_data];
+}
+}
++ (NSString *)encryptToHexString: (NSData *)data stringKey:(NSString *)key {
+    NSData * encrypt_data = [self encrypt:data stringKey:key];
+    return [self convertBytesToHex:encrypt_data];
+}
++ (NSString *) encryptStringToHexString:(NSString *)data key:(NSData *)key {
+    NSData * encrypt_data = [self encryptString:data key:key];
+    return [self convertBytesToHex:encrypt_data];
+}
++ (NSString *) encryptStringToHexString:(NSString *)data stringKey:(NSString *)key {
+    NSData * encrypt_data = [self encryptString:data stringKey:key];
+    return [self convertBytesToHex:encrypt_data];
 }
 + (NSData *) decrypt:(NSData *)data key:(NSData *)key {
     size_t out_len;
@@ -243,6 +259,36 @@ static uint8_t * xxtea_ubyte_decrypt(const uint8_t * data, size_t len, const uin
 }
 + (NSString *) decryptBase64StringToString:(NSString *)data stringKey:(NSString *)key {
     return [self decryptBase64StringToString:data key:[key dataUsingEncoding:NSUTF8StringEncoding]];
+}
++ (NSData *) convertHexToBytes:(NSString *)hexString {
+    NSString * formatData = [hexString stringByReplacingOccurrencesOfString:@" " withString:@""];
+    NSMutableData * bytesData = [[NSMutableData alloc] init];
+    unsigned char whole_byte;
+    char byte_chars[3] = {'\0','\0','\0'};
+    int i;
+    for (i=0; i < [formatData length]/2; i++) {
+        byte_chars[0] = [formatData characterAtIndex:i*2];
+        byte_chars[1] = [formatData characterAtIndex:i*2+1];
+        whole_byte = strtol(byte_chars, NULL, 16);
+        [bytesData appendBytes:&whole_byte length:1]; 
+    }
+    return bytesData;
+}
++ (NSData *) decryptHexString:(NSString *)data key:(NSData *)key {
+    NSData * bytesData = [self convertHexToBytes:data];
+    return [self decrypt:bytesData key:key];
+}
++ (NSData *) decryptHexString:(NSString *)data stringKey:(NSString *)key {
+    NSData * bytesData = [self convertHexToBytes:data];
+    return [self decrypt:originalHashData stringKey:key];
+}
++ (NSString *) decryptHexStringToString:(NSString *)data key:(NSData *)key {
+    NSData * bytesData = [self convertHexToBytes:data];
+    return [self decryptToString: data key:key];
+}
++ (NSString *) decryptHexStringToString:(NSString *)data stringKey:(NSString *)key {
+    NSData * bytesData = [self convertHexToBytes:data];
+    return [self decryptToString: data stringKey:key];
 }
 
 @end

--- a/src/XXTEA.m
+++ b/src/XXTEA.m
@@ -189,6 +189,15 @@ static uint8_t * xxtea_ubyte_decrypt(const uint8_t * data, size_t len, const uin
 }
 + (NSData *) encrypt:(NSData *)data stringKey:(NSString *)key {
     return [self encrypt:data key:[key dataUsingEncoding:NSUTF8StringEncoding]];
+}  
++ (NSString *)encryptWithHexString: (NSString *)data stringKey:(NSString *)key {
+    NSData * encrypt_data = [XXTEA encryptString:data stringKey:key];
+    const unsigned char *dataBytes = [encrypt_data bytes];
+    NSMutableString *hexString = [NSMutableString stringWithCapacity:[encrypt_data length] * 2];
+    for (int i=0; i<[encrypt_data length]; ++i) {
+        [hexString appendFormat:@"%02lX", (unsigned long)dataBytes[i]];
+    }
+    return hexString;
 }
 + (NSString *) encryptToBase64String:(NSData *)data key:(NSData *)key {
     return [[self encrypt:data key:key] base64EncodedStringWithOptions:0];


### PR DESCRIPTION
# New:
- Original XXTEA encryption in the README will only return NSData. For this pull request, it allows return HexString if needed.